### PR TITLE
DUPLO-6770 - Dockerfile for portability

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.*
+target
+*.md
+!.gitignore
+!.envrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.19.3 as builder 
+
+WORKDIR /go/src/app
+
+COPY . .
+
+RUN CGO_ENABLED=0 go build -o /go/bin/app
+
+FROM gcr.io/distroless/static-debian11 as runner
+
+COPY --from=builder /go/bin/app /
+COPY ./scripts /scripts
+COPY .gitignore /.gitignore
+COPY .envrc /.envrc
+
+CMD ["/app"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,12 @@
+services:
+  tenant-tf-generator:
+    image: tenant-tf-generator:latest
+    build: 
+      context: .
+      # target: builder
+    # command: [ "tail", "-f", "/dev/null" ] # use this for debugging
+    tty: true
+    volumes:
+    - ./target:/target
+    env_file:
+    - .envrc


### PR DESCRIPTION
Currently you must be in the directory of this project to run. With the docker-compose file provided you can now run this anywhere. Also you would not need to constantly change the .envrc file this way. 