### PR TITLE
ssm-params secret palceholder support based on env var.

### DIFF
--- a/tf-generator/aws-services/ssm-params.go
+++ b/tf-generator/aws-services/ssm-params.go
@@ -117,6 +117,10 @@ func (ssmParams *SsmParams) Generate(config *common.Config, client *duplosdk.Cli
 				}
 			}
 
+			if ssmParam.Type == "SecureString" && config.EnableSecretPlaceholder {
+				ssmParamBody.SetAttributeValue("value" , cty.StringVal(config.K8sSecretPlaceholder))
+			}
+
 			if len(ssmDetails.Description) > 0 {
 				ssmParamBody.SetAttributeValue("description",
 					cty.StringVal(ssmDetails.Description))


### PR DESCRIPTION
Draft PR for also making ssm params of type "SecretString" have the placeholder value. This concept code works, but is utilizing the `enable_k8s_secret_placeholder` and `k8s_secret_placeholder` env variables