### PR TITLE
DUPLO-18548  Terraform exporter fails on ECR with / in name

### DIFF
--- a/duplosdk/utils.go
+++ b/duplosdk/utils.go
@@ -51,6 +51,14 @@ func EncodePathParam(param string) string {
 	return url.PathEscape(url.PathEscape(param))
 }
 
+func EncodePathParamForFileName(param string) string {
+	replaceSymbol := "_" // Replace "/" with this symbol
+
+	// Replace "/" with userSymbol
+	return strings.ReplaceAll(param, "/", replaceSymbol)
+
+}
+
 // GetDuploServicesPrefix builds a duplo resource name, given a tenant ID.
 func (c *Client) GetDuploServicesPrefix(tenantID string) (string, ClientError) {
 	return c.GetResourcePrefix("duploservices", tenantID)

--- a/tf-generator/aws-services/ecr.go
+++ b/tf-generator/aws-services/ecr.go
@@ -43,7 +43,7 @@ func (ecr *ECR) Generate(config *common.Config, client *duplosdk.Client) (*commo
 			hclFile := hclwrite.NewEmptyFile()
 
 			// create new file on system
-			path := filepath.Join(workingDir, "ecr-"+shortName+".tf")
+			path := filepath.Join(workingDir, duplosdk.EncodePathParamForFileName("ecr-"+shortName+".tf"))
 			tfFile, err := os.Create(path)
 			if err != nil {
 				fmt.Println(err)


### PR DESCRIPTION
replaced path symbol forward slash with under score while creating filename for ecr