### PR TITLE
DUPLO-25244 TF Export:Batch: make run is failing with "panic: runtime error: index out of range [0] with length 0" when hosts of Batch Compute Environment are available in tenant

### DIFF
--- a/tf-generator/aws-services/hosts.go
+++ b/tf-generator/aws-services/hosts.go
@@ -34,6 +34,9 @@ func (h *Hosts) Generate(config *common.Config, client *duplosdk.Client) (*commo
 		log.Println("[TRACE] <====== Hosts TF generation started. =====>")
 		for _, host := range *list {
 			shortName := host.FriendlyName
+			if shortName == "" {
+				continue
+			}
 			if strings.Contains(host.FriendlyName, "duploservices-"+config.TenantName+"-") {
 				shortName = host.FriendlyName[len("duploservices-"+config.TenantName+"-"):len(host.FriendlyName)]
 			}


### PR DESCRIPTION
On batch compute resource export created ec2 host has no friendly name (cause of error)
Checking if friendly name is not present then continue